### PR TITLE
Add AsyncManager.InitializeForEditorTests()

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -244,3 +244,19 @@ public struct WaitForTimeSpan : IAwaitInstruction
 	}	
 }
 ```
+
+# Usage with Unity EditorTests (unit tests with NUnit)
+
+When running unit tests, `AsyncManager` is not automatically initialized. Call `AsyncManager.InitializeForEditorTests()` in your test OneTimeSetUp method, for example like this:
+
+```c#
+// In your test class
+
+[OneTimeSetUp]
+public void OneTimeSetUp()
+{
+	AsyncManager.InitializeForEditorTests();
+
+	// Other setup code here
+}
+```

--- a/UnityAsync/Assets/UnityAsync/Manager/AsyncManager.cs
+++ b/UnityAsync/Assets/UnityAsync/Manager/AsyncManager.cs
@@ -55,7 +55,19 @@ namespace UnityAsync
 			fixedUpdates = new ContinuationProcessorGroup();
 
 			Instance = new GameObject("Async Manager").AddComponent<AsyncManager>();
-			DontDestroyOnLoad(Instance);
+			if(!Application.isEditor) // DontDestroyOnLoad can not be called in editor mode
+				DontDestroyOnLoad(Instance);
+		}
+
+		/// <summary>
+		/// Initializes the manager explicitly. Typically used when running Unity Editor tests (NUnit unit tests).
+		/// </summary>
+		public static void InitializeForEditorTests()
+		{
+			Initialize();
+			
+			// Do not run tasks in background when testing:
+			BackgroundSyncContext = UnitySyncContext;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Enables relatively easy unit testing.

Fixes https://github.com/muckSponge/UnityAsync/issues/7